### PR TITLE
ADD / 레이드 상태 조회 API 생성

### DIFF
--- a/src/raid/dto/raidStatusDto.ts
+++ b/src/raid/dto/raidStatusDto.ts
@@ -1,0 +1,4 @@
+export interface raidStatus {
+  canEnter: boolean;
+  enteredUserId: number;
+}

--- a/src/raid/raid.service.ts
+++ b/src/raid/raid.service.ts
@@ -8,8 +8,17 @@ import { RaidRecord } from './entities/raid.entity';
 export class RaidService {
   constructor(
     @InjectRepository(RaidRecord)
-    private readonly raidRecordRepositroy: Repository<RaidRecord>,
+    private readonly raidRecordRepository: Repository<RaidRecord>,
     @InjectRepository(User)
-    private readonly userRepositroy: Repository<User>,
+    private readonly userRepository: Repository<User>,
   ) {}
+
+  async fetchRecentRaidRecord() {
+    const db = await this.raidRecordRepository
+      .createQueryBuilder('record')
+      .leftJoinAndSelect('record.user', 'user')
+      .orderBy('enterTime', 'DESC')
+      .getOne();
+    if (db) return db;
+  }
 }


### PR DESCRIPTION
- 레이드 상태 조회 API 생성 (GET, '/bossRaid')
- 컨트롤러 컨스트럭터 => cacheManager 앞에 private readonly 붙였습니다
- 서비스 컨스트럭터 => 오타 수정
- 레이드 상태 조회 dto 생성

Relate to: [Task] 레이드 api 초기 작업 #5