### PR TITLE
REFACTOR / 레이드 상태 조회 타입 수정

### DIFF
--- a/src/raid/dto/raidStatus.dto.ts
+++ b/src/raid/dto/raidStatus.dto.ts
@@ -6,8 +6,4 @@ export class RaidStatus {
 
   @ApiProperty({ description: '레이드를 이미 진행중인 유저의 id', example: 1 })
   enteredUserId: number;
-
-  @ApiProperty({ description: '레이드 레코드 아이디입니다.', example: 1 })
-  raidRecordId: number;
 }
-

--- a/src/raid/raid.controller.ts
+++ b/src/raid/raid.controller.ts
@@ -9,20 +9,19 @@ import { ApiBearerAuth, ApiCreatedResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/passport/guard/jwtAuthGuard';
 import { MSG } from 'src/common/response.enum';
 import { TopRankerListDto } from './dto/topRankerList.dto';
+import { IRaidStatus } from './raidStatus.interface';
 
 @ApiBearerAuth('access_token')
 @UseGuards(JwtAuthGuard)
 @ApiTags('BossRaid')
 @Controller('bossRaid')
 export class RaidController {
-  constructor(
-    private readonly raidService: RaidService,
-  ) {}
+  constructor(private readonly raidService: RaidService) {}
 
   /**
    * @작성자 김태영
    * @description 레이드 상태 조회 컨트롤러
-  */
+   */
   @ApiCreatedResponse({
     status: MSG.getRaidStatus.code,
     description: MSG.getRaidStatus.msg,
@@ -31,13 +30,16 @@ export class RaidController {
   async getRaidStatus(): Promise<RaidStatus> {
     try {
       // 레디스 조회시 결과
-      const redisResult: RaidStatus = await this.raidService.getStatusFromRedis();
+      const redisResult: IRaidStatus = await this.raidService.getStatusFromRedis();
+      delete redisResult.raidRecordId;
 
       return redisResult;
     } catch (error) {
       console.log(error);
       //레디스 에러 시 DB에서의 상태 조회 결과
       const dbResult = await this.raidService.getStatusFromDB();
+      delete dbResult.raidRecordId;
+
       return dbResult;
     }
   }
@@ -45,7 +47,7 @@ export class RaidController {
   /**
    * @작성자 박신영
    * @description 레이드 시작 컨트롤러
-  */
+   */
   @ApiBody({ type: RaidEnterDto })
   @ApiCreatedResponse({
     description: MSG.enterBossRaid.msg,
@@ -61,7 +63,7 @@ export class RaidController {
   /**
    * @작성자 김용민
    * @description 레이드 종료 컨트롤러
-  */
+   */
   @ApiBody({ type: RaidEndDto })
   @Patch('end')
   endRaid(@Body() raidEndDto: RaidEndDto): Promise<void> {
@@ -71,7 +73,7 @@ export class RaidController {
   /**
    * @작성자 염하늘
    * @description 레이드 유저 랭킹 조회 컨트롤러
-  */
+   */
   @ApiBody({ type: TopRankerListDto })
   @Post('topRankerList')
   topRankerList(@Body() dto: TopRankerListDto) {

--- a/src/raid/raidStatus.interface.ts
+++ b/src/raid/raidStatus.interface.ts
@@ -1,0 +1,5 @@
+export interface IRaidStatus {
+  canEnter: boolean;
+  enteredUserId: number;
+  raidRecordId: number;
+}


### PR DESCRIPTION
- 레이드 상태 인터페이스 추가
- 레디스 저장시 타입 IRedisStatus 로 전부 변경
- 상태 조회 리턴 타입을 RedisStatus.dto로 변경

FIX / 레이드 종료 db 저장 로직 수정

- db 저장 부분에서 문제가 생겨 트랜젝션 수정
- 유저 스코어 저장 및 레이드 상태 레디스 삭제 확인
- 랭크 정보 업데이트 정상 확인

Relate to: [Task] 레이드 종료 시 랭킹에 반영 #40 , [Task] 레이드 상태 조회 API 구현 #19