### PR TITLE
FIX / 보스레이드 정보가 레디스에 저장되지 않던 버그 수정

### DIFF
--- a/src/raid/raid.service.ts
+++ b/src/raid/raid.service.ts
@@ -144,7 +144,7 @@ export class RaidService {
 
     // 레이드 상태가 유효한 값인지 확인
     await this.checkRaidStatus(raidStatus, userId, raidRecordId);
-
+    
     const record: RaidRecord = await this.getRaidRecordById(raidRecordId);
     const score = await this.cacheManager.get(`level_${record.level}`);
     if (!score) {
@@ -248,10 +248,10 @@ export class RaidService {
     const staticData = await AxiosHelper.getInstance();
     const bossRaid = staticData.data.bossRaids[0];
 
-    await this.cacheManager.set('bossRaidLimitSeconds', bossRaid.bossRaidLimitSeconds);
-    await this.cacheManager.set('level_0', bossRaid.levels[0].score);
-    await this.cacheManager.set('level_1', bossRaid.levels[1].score);
-    await this.cacheManager.set('level_2', bossRaid.levels[2].score);
+    await this.cacheManager.set('bossRaidLimitSeconds', bossRaid.bossRaidLimitSeconds, { ttl: 0 });
+    await this.cacheManager.set('level_0', bossRaid.levels[0].score, { ttl: 0 });
+    await this.cacheManager.set('level_1', bossRaid.levels[1].score, { ttl: 0 });
+    await this.cacheManager.set('level_2', bossRaid.levels[2].score, { ttl: 0 });
   }
 
   /**


### PR DESCRIPTION
만료시간 기본 값이 5초여서 발생했던 문제
만료시간 없게 설정하여 해결

Resolve: #83